### PR TITLE
Support Akamai OPEN Authentication and CCU v3 APIs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{py,rst,ini}]
+indent_style = space
+indent_size = 4

--- a/README.rst
+++ b/README.rst
@@ -54,13 +54,14 @@ TODO: discuss options for rate-limiting
 Example:
 ::
 
-	>>> pr = PurgeRequest(FIXME)
-	>>> pr.add("http://www.example.com/url-1.html")
-	>>> pr.add(u"http://www.example.com/url-2.html")
-	>>> urls_purged, responses = pr.purge()
-    ({u'purgeId': u'2d342226-1bca-11e7-bb13-c146e59a2657', u'progressUri': u'/ccu/v2/purges/2d342226-1bca-11e7-bb13-c146e59a2657', u'estimatedSeconds': 240, u'supportId': u'17PY1491594081381157-235812032', u'httpStatus': 201, u'detail': u'Request accepted.', u'pingAfterSeconds': 240}, 1)
-	>>> print pr.urls
-	[]
+    >>> pr = PurgeRequest()
+    >>> pr.add("http://www.example.com/url-1.html")
+    >>> pr.add(u"http://www.example.com/url-2.html")
+    >>> for url_batch, response in pr.purge():
+        print(resp.status_code, len(url_batch))
+    201 2
+    >>> print pr.urls
+    []
 
 
 Using Django Signals
@@ -77,16 +78,16 @@ object or QuerySet, then ``get_absolute_url()`` must be defined on every object.
 Example of signalling to immediately perform the request:
 ::
 
-	>>> from django_akamai.signals import purge_request, queue_purge_request
-	>>> obj = MyObject.objects.get(pk=3)
-	>>> obj.get_absolute_url()
-	u'http://www.example.com/blahblah.html'
-	>>> purge_request.send(obj)
+    >>> from django_akamai.signals import purge_request, queue_purge_request
+    >>> obj = MyObject.objects.get(pk=3)
+    >>> obj.get_absolute_url()
+    u'http://www.example.com/blahblah.html'
+    >>> purge_request.send(obj)
 
 Or, to queue the request using Celery:
 ::
 
-	>>> queue_purge_request.send(obj)
+    >>> queue_purge_request.send(obj)
 
 
 Using Tasks
@@ -94,8 +95,6 @@ Using Tasks
 To use the task directly, import ``PurgeRequestTask`` from tasks.py thusly:
 ::
 
-	>>> from akamai.tasks import PurgeRequestTask
-	>>> obj = MyObject.objects.get(pk=3)
-	>>> result = PurgeRequestTask.delay(obj)
-	>>> print result
-	1
+    >>> from akamai.tasks import PurgeRequestTask
+    >>> obj = MyObject.objects.get(pk=3)
+    >>> PurgeRequestTask.delay(obj)

--- a/django_akamai/purge.py
+++ b/django_akamai/purge.py
@@ -199,10 +199,8 @@ class PurgeRequest(object):
                 if not isinstance(next_url, bytes):
                     next_url = next_url.encode('utf-8')
 
-                next_size = len(next_url)
-
                 batch.append(next_url)
-                batch_size += next_size
+                batch_size += len(next_url)
 
             if batch:
                 data = {'objects': batch}

--- a/django_akamai/signals.py
+++ b/django_akamai/signals.py
@@ -19,6 +19,7 @@ u'http://www.example.com/blahblah.html'
 Or:
 >>> queue_purge_request.send(obj)
 """
+
 from __future__ import absolute_import
 
 from django.dispatch import Signal
@@ -27,7 +28,7 @@ from .purge import PurgeRequest
 
 try:
     from .tasks import PurgeRequestTask
-except:
+except ImportError:
     tasks_available = False
 else:
     tasks_available = True
@@ -35,11 +36,13 @@ else:
 
 purge_request = Signal()
 
+
 def purge_request_handler(sender, **kwargs):
     pr = PurgeRequest()
     pr.add(sender.get_absolute_url())
     result = pr.purge()
     return result
+
 
 purge_request.connect(purge_request_handler)
 
@@ -48,6 +51,6 @@ if tasks_available:
     queue_purge_request = Signal()
 
     def queue_purge_request_handler(sender, **kwargs):
-        result = PurgeRequestTask.delay(sender)
+        PurgeRequestTask.delay(sender)
 
     queue_purge_request.connect(queue_purge_request_handler)

--- a/django_akamai/signals.py
+++ b/django_akamai/signals.py
@@ -40,8 +40,7 @@ purge_request = Signal()
 def purge_request_handler(sender, **kwargs):
     pr = PurgeRequest()
     pr.add(sender.get_absolute_url())
-    result = pr.purge()
-    return result
+    pr.purge_all()
 
 
 purge_request.connect(purge_request_handler)

--- a/django_akamai/tasks.py
+++ b/django_akamai/tasks.py
@@ -16,7 +16,7 @@ from .purge import PurgeRequest
 
 
 class PurgeRequestTask(Task):
-    default_retry_delay = 60 * 2 # seconds here, so 2 minutes total
+    default_retry_delay = 60 * 2    # seconds here, so 2 minutes total
     max_retries = 5
 
     def run(self, urls, **kwargs):

--- a/django_akamai/tasks.py
+++ b/django_akamai/tasks.py
@@ -21,5 +21,6 @@ class PurgeRequestTask(Task):
 
     def run(self, urls, **kwargs):
         pr = PurgeRequest(urls=urls)
-        result, num_urls = pr.purge()
+        num_urls = len(pr.urls)
+        pr.purge_all()
         return num_urls

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,14 @@ from setuptools import setup
 
 setup(
     name='django-akamai',
-    version='2.0.0pre1',
-    description='A Django app for performing Akamai CCUAPI purge requests',
+    version='2.0.0.dev3',
+    description='A Django app for performing Akamai purge requests',
     author='Ben Boyd',
     author_email='beathan@gmail.com',
     long_description=open('README.rst', 'r').read(),
     url='https://github.com/beathan/django-akamai',
     packages=['django_akamai'],
-    requires=[
+    install_requires=[
         'requests[security]',
         'edgegrid-python',
     ],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='django-akamai',
-    version='2.0.0.dev3',
+    use_scm_version=True,
     description='A Django app for performing Akamai purge requests',
     author='Ben Boyd',
     author_email='beathan@gmail.com',
@@ -15,4 +15,7 @@ setup(
         'requests[security]',
         'edgegrid-python',
     ],
+    setup_requires=[
+        'setuptools_scm',
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -4,17 +4,15 @@ from setuptools import setup
 
 setup(
     name='django-akamai',
-    version='1.0.1',
+    version='2.0.0pre1',
     description='A Django app for performing Akamai CCUAPI purge requests',
     author='Ben Boyd',
     author_email='beathan@gmail.com',
     long_description=open('README.rst', 'r').read(),
     url='https://github.com/beathan/django-akamai',
     packages=['django_akamai'],
-    requires=['requests'],
-
-    # We need to include our WSDL file which means that we can't be installed
-    # as an egg and must include a non-Python resource:
-    include_package_data=True,
-    zip_safe=False,
+    requires=[
+        'requests[security]',
+        'edgegrid-python',
+    ],
 )


### PR DESCRIPTION
This is a major version increment which supports the OPEN Authentication and CCU v3 APIs using the `edgegrid-python` client.

Since this is a backwards-incompatible change several of the function call and response signatures have been updated, most notably related to URL batching where the request is now assembled using the API size limit rather than the number of URLs and has been refactored to use a generator
interface to simplify the process of providing progress information or custom rate-limiting behaviour.

Closes #4.